### PR TITLE
fixed version incompatibility on spaWebServer.cpp line 556

### DIFF
--- a/lib/spaWebServer/spaWebServer.cpp
+++ b/lib/spaWebServer/spaWebServer.cpp
@@ -553,7 +553,7 @@ void handleNotFound(AsyncWebServerRequest *request)
   int i;
   for (i = 0; i < headers; i++)
   {
-    AsyncWebHeader *h = request->getHeader(i);
+    const AsyncWebHeader *h = request->getHeader(i);
     Log.verbose("HEADER[%s]: %s\n", h->name().c_str(), h->value().c_str());
   }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -83,8 +83,8 @@ lib_deps = ${com.lib_deps}
 build_flags =
   ${com.build_flags}
   '-DPRODUCTION'
-;	'-DLOCAL_CONNECT'
-;  '-DLOCAL_CLIENT'
+	'-DLOCAL_CONNECT'
+  '-DLOCAL_CLIENT'
 ;	'-DBRIDGE'
   '-DREMOTE_CLIENT'
 ;	'-DTELNET_LOG'


### PR DESCRIPTION
## :recycle: Current situation

*Hi, first time doing a PR, ever, but I love this project and want to make it easier for noob's like me.
So I tried to compile but got an error.  From what I can tell, the ESPAsyncWebServer library was updated by the project code is older.  *

## :bulb: Proposed solution

*Changed line 556.  I'm not sure if this is the correct way to do this, but it did fix my instance and let it compile.  I also uncommented 2 lines in the ESP32serial environment, as they should probably be enabled by default.  Hope this is helpful to you.  Thank you for all you do.*



